### PR TITLE
Defect fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 - Defect where a lack of any Qualified Dividends would raise an exception during Dividend Analysis.
 - Defect where a sparely populated dividends section would raise an exception when parsing the grand total section.
+- Major defect surrounding dividends that are split between qualified and nonqualified. The shares count was totally wrong, and the amount to disqualify could be too high.
 
 ## [2.1.0] 2023-04-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Defect where a lack of any Qualified Dividends would raise an exception during Dividend Analysis.
 - Defect where a sparely populated dividends section would raise an exception when parsing the grand total section.
 - Major defect surrounding dividends that are split between qualified and nonqualified. The shares count was totally wrong, and the amount to disqualify could be too high.
+- Improve multi-line dividend name parsing (for cases when there is just one dividend for the security).
 
 ## [2.1.0] 2023-04-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## [2.1.1] 2023-04-08
+### Fixed
+- Defect where a lack of any Qualified Dividends would raise an exception during Dividend Analysis.
+
 ## [2.1.0] 2023-04-08
 ### Changed
 - Added short-hand flags for the existing command line parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [2.1.1] 2023-04-08
 ### Fixed
 - Defect where a lack of any Qualified Dividends would raise an exception during Dividend Analysis.
+- Defect where a sparely populated dividends section would raise an exception when parsing the grand total section.
 
 ## [2.1.0] 2023-04-08
 ### Changed

--- a/parse_1099/__version__.py
+++ b/parse_1099/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'parse_1099'
 __description__ = 'Parses 1099 tax document (1099-B, 1099-INT, 1099-DIV) from PDF into CSV format and performs simple analysis'
 __url__ = ''
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 __author__ = 'Andrew Wells, Keun Tae (Kevin) Park'
 __author_email__ = 'ajwells@uchicago.com, kevin.park1217@gmail.com'
 __keywords__ = 'pdf, csv, parsing, excel, spreadsheet, tax, 1099'

--- a/parse_1099/dividends/dividend_analyzer.py
+++ b/parse_1099/dividends/dividend_analyzer.py
@@ -113,7 +113,7 @@ class DividendAnalyzer():
 
                         if self.report_prefix is not None:
                             for sale in disqualified_sales:
-                                sale.add_note(f"Disqualifies dividend {working_dividend} with exdate {exdate} and payout ${amount_per_share}")
+                                sale.add_note(f"Disqualifies dividend {dividend} with exdate {exdate} and payout ${amount_per_share}")
                             detailed_report.extend(disqualified_sales)
 
                 if self.report_prefix is not None:

--- a/parse_1099/dividends/v1/dividends.py
+++ b/parse_1099/dividends/v1/dividends.py
@@ -46,7 +46,7 @@ class Dividends(DividendsInterface):
 
     def disqualify(self, shares_disqualified, share_dividend_amount) -> "DividendsInterface":
         '''Produces a new Dividend of type 'nonqualified dividend' and adjusts this dividend accordingly'''
-        disqualification_amount = shares_disqualified * share_dividend_amount
+        disqualification_amount = round(shares_disqualified * share_dividend_amount, 2)
         dividend_data = [self.get("security"), self.get("cusip"), \
                 self.get("transaction_date"), str(disqualification_amount), "Nonqualified dividend"]
         if self.include_notes:

--- a/parse_1099/dividends/v1/dividends.py
+++ b/parse_1099/dividends/v1/dividends.py
@@ -64,7 +64,7 @@ class Dividends(DividendsInterface):
         return disqualified_dividend
 
     def copy(self) -> "DividendsInterface":
-        return Dividends(self.data, self.include_notes)
+        return Dividends(self.data.copy(), self.include_notes)
 
     @staticmethod
     def parse(raw_data: "list[str]", include_notes: bool) -> "list[Dividends]":

--- a/parse_1099/dividends/v1/dividends.py
+++ b/parse_1099/dividends/v1/dividends.py
@@ -184,6 +184,16 @@ class Dividends(DividendsInterface):
                 subtotal_amount = atof(raw_data[cursor-1])
                 subtotals[raw_data[cursor]] = subtotal_amount
             cursor += 1
+
+        total_title = "Total Dividends & distributions"
+        tax_exempt_title = "Total Tax-exempt dividends"
+        foreign_tax_withheld_title = "Total Foreign tax withheld"
+        if total_title not in subtotals:
+            subtotals[total_title] = 0
+        if tax_exempt_title not in subtotals:
+            subtotals[tax_exempt_title] = 0
+        if foreign_tax_withheld_title not in subtotals:
+            subtotals[foreign_tax_withheld_title] = 0
         
         return DividendsTotal(subtotals["Total Dividends & distributions"], \
             tax_exempt=subtotals["Total Tax-exempt dividends"], \

--- a/parse_1099/dividends/v1/dividends_parser.py
+++ b/parse_1099/dividends/v1/dividends_parser.py
@@ -10,6 +10,8 @@ from .dividends import Dividends
 
 class DividendsParser(SubparserInterface):
 
+    _transaction_type_pattern = compile(".*(dividend|withheld).*")
+
     def __init__(self, pdf_file, include_dividend_notes: bool = False):
         super().__init__(pdf_file)
         self.include_notes = include_dividend_notes
@@ -45,7 +47,8 @@ class DividendsParser(SubparserInterface):
                     # fix multi-line securities names. Not ideal, could improve
                     if (security_header_idx > 0 and \
                         Dividends._security_pattern.match(strings[security_header_idx-1]) and \
-                        not Dividends._subtotal_pattern.match(strings[security_header_idx-1])):
+                        not Dividends._subtotal_pattern.match(strings[security_header_idx-1]) and \
+                        not DividendsParser._transaction_type_pattern.match(strings[security_header_idx-1])): # in the case where there's just one dividend for a security, there isn't a subtotal
                         strings[security_header_idx] = f"{strings[security_header_idx-1]} {strings[security_header_idx]}"
 
                     # case: this isn't the first header on the page

--- a/parse_1099/dividends/v1/dividends_parser.py
+++ b/parse_1099/dividends/v1/dividends_parser.py
@@ -36,8 +36,11 @@ class DividendsParser(SubparserInterface):
                         if Dividends._security_pattern.match(strings[i]) and Dividends._cusip_pattern.match(strings[i+1]):
                             return i
 
+                # robinhood header can look like a security header since their account ids are the same form as CUSIPs
+                # endeavor to pass over these false matches by advancing at least as far as the title, which in the current version gets beyond the robinhood account string
+                header_title_idx = strings.index(indicator_str)
                 prev_header_idx: int = -1
-                security_header_idx = get_next_security_index(strings)
+                security_header_idx = get_next_security_index(strings, header_title_idx+1)
                 while security_header_idx:
                     # fix multi-line securities names. Not ideal, could improve
                     if (security_header_idx > 0 and \

--- a/parse_1099/main.py
+++ b/parse_1099/main.py
@@ -64,7 +64,8 @@ def main():
                 if adjusted_dividends is not None:
                     assert(adjusted_total is not None) # this should never be none if there are dividends
                     report = "For more details, see the sales_with_short_holding_periods report." if args.analysis_report else "For more details, use the --analysis-report flag."
-                    print(f">>> Analyzed dividends and determinded that ${adjusted_total.disqualified} of qualified dividends should be considered nonqualified due to short holding periods around the ex-dividend date. The disqualification is reflected in the adjusted_dividends csv. {report}")
+                    print(f">>> Analyzed dividends and determinded that ${adjusted_total.disqualified:.2f} of qualified dividends should be considered nonqualified due to \
+                          short holding periods around the ex-dividend date. The disqualification is reflected in the adjusted_dividends csv. {report}")
                     adjusted_dividends_csv = f"{args.csv}_adjusted_dividends.csv"
                     csv_writer.write_to_csv(adjusted_dividends_csv, adjusted_dividends)
 

--- a/parse_1099/main.py
+++ b/parse_1099/main.py
@@ -63,10 +63,12 @@ def main():
                 adjusted_dividends, adjusted_total = dividend_analyzer.get_disqualified_dividends(contents)
                 if adjusted_dividends is not None:
                     assert(adjusted_total is not None) # this should never be none if there are dividends
-                    print(f"Analyzed dividends and determinded that ${adjusted_total.disqualified} of qualified dividends should be considered nonqualified due to short holding periods around the ex-dividend date")
+                    report = "For more details, see the sales_with_short_holding_periods report." if args.analysis_report else "For more details, use the --analysis-report flag."
+                    print(f">>> Analyzed dividends and determinded that ${adjusted_total.disqualified} of qualified dividends should be considered nonqualified due to short holding periods around the ex-dividend date. The disqualification is reflected in the adjusted_dividends csv. {report}")
                     adjusted_dividends_csv = f"{args.csv}_adjusted_dividends.csv"
                     csv_writer.write_to_csv(adjusted_dividends_csv, adjusted_dividends)
 
-                    print(adjusted_total)
+                    if args.validate:
+                        print(adjusted_total)
     else:
         print(f">>> No data to save to file")


### PR DESCRIPTION
- Defect where a lack of any Qualified Dividends would raise an exception during Dividend Analysis.
- Defect where a sparely populated dividends section would raise an exception when parsing the grand total section.
- Major defect surrounding dividends that are split between qualified and nonqualified. The shares count was totally wrong, and the amount to disqualify could be too high.
- Improve multi-line dividend name parsing (for cases when there is just one dividend for the security).